### PR TITLE
Swallow restart

### DIFF
--- a/DebuggerGame/Assets/Scenes/level 1.unity
+++ b/DebuggerGame/Assets/Scenes/level 1.unity
@@ -123,6 +123,52 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &70473967
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 70473968}
+  - component: {fileID: 70473969}
+  m_Layer: 0
+  m_Name: BasicFlyEnemy (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &70473968
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 70473967}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2012515070}
+  m_Father: {fileID: 769082870}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &70473969
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 70473967}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 53e5792f91e0248259e52d85bc33f852, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rulesEnabled: 1
+  myTurn: 0
 --- !u!1 &166607692
 GameObject:
   m_ObjectHideFlags: 0
@@ -139,7 +185,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &166607693
 Transform:
   m_ObjectHideFlags: 0
@@ -234,6 +280,63 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &228788128
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1976379499}
+    m_Modifications:
+    - target: {fileID: 1007193898850059639, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_Name
+      value: BasicFlyEnemySprite
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -428,7 +531,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &765211975
 Transform:
   m_ObjectHideFlags: 0
@@ -508,9 +611,16 @@ Transform:
   - {fileID: 1614833428}
   - {fileID: 166607693}
   - {fileID: 765211975}
+  - {fileID: 1976379499}
+  - {fileID: 70473968}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1020493456 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+  m_PrefabInstance: {fileID: 228788128}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1161634390
 GameObject:
   m_ObjectHideFlags: 0
@@ -849,6 +959,63 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rulesEnabled: 1
   myTurn: 0
+--- !u!1001 &1781084478
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 70473968}
+    m_Modifications:
+    - target: {fileID: 1007193898850059639, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_Name
+      value: BasicFlyEnemySprite
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
 --- !u!1 &1932928073
 GameObject:
   m_ObjectHideFlags: 0
@@ -931,3 +1098,54 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1976379498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1976379499}
+  - component: {fileID: 1976379500}
+  m_Layer: 0
+  m_Name: BasicFlyEnemy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1976379499
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976379498}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1020493456}
+  m_Father: {fileID: 769082870}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1976379500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976379498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 53e5792f91e0248259e52d85bc33f852, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rulesEnabled: 1
+  myTurn: 0
+--- !u!4 &2012515070 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4813943156607320776, guid: 7134a8bf33f79bf4e9236a2103bca816, type: 3}
+  m_PrefabInstance: {fileID: 1781084478}
+  m_PrefabAsset: {fileID: 0}

--- a/DebuggerGame/Assets/Scenes/level 1.unity
+++ b/DebuggerGame/Assets/Scenes/level 1.unity
@@ -412,6 +412,51 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &765211974
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 765211975}
+  - component: {fileID: 765211976}
+  m_Layer: 0
+  m_Name: TestBugHoldObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &765211975
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 765211974}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1369184542}
+  m_Father: {fileID: 769082870}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &765211976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 765211974}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58f40d18061c6d44c90f34ec5d9629d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rulesEnabled: 1
 --- !u!1 &769082868
 GameObject:
   m_ObjectHideFlags: 0
@@ -462,6 +507,7 @@ Transform:
   - {fileID: 1226408674}
   - {fileID: 1614833428}
   - {fileID: 166607693}
+  - {fileID: 765211975}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -631,6 +677,88 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1325772198}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: ebe73ca9363db456bacf42c025bb4847, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1369184541
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1369184542}
+  - component: {fileID: 1369184543}
+  m_Layer: 0
+  m_Name: Circle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1369184542
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369184541}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children: []
+  m_Father: {fileID: 765211975}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1369184543
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1369184541}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0

--- a/DebuggerGame/Assets/Scripts/Board Scripts/Board.cs
+++ b/DebuggerGame/Assets/Scripts/Board Scripts/Board.cs
@@ -27,7 +27,11 @@ public class Board : MonoBehaviour
 
     public List<BoardObject> boardObjects;
 
-    public void BugCountUpdate()
+    public void BugCountIncrement()
+    {
+        numBugs++;
+    }
+    public void BugCountDecrement()
     {
         numBugs--;
     }
@@ -257,6 +261,10 @@ public class Board : MonoBehaviour
     {
         winConditions[index] = value;
         gameWon = !winConditions.Contains(false);
+        if (gameWon)
+        {
+            Debug.Log("You won woo.");
+        }
     }
 
 

--- a/DebuggerGame/Assets/Scripts/Board Scripts/Board.cs
+++ b/DebuggerGame/Assets/Scripts/Board Scripts/Board.cs
@@ -118,7 +118,7 @@ public class Board : MonoBehaviour
 
     public List<IActionRule> actionRules = new List<IActionRule>();
 
-    public Dictionary<Vector2Int, CollidableObject> collidableCoordinates = new Dictionary<Vector2Int, CollidableObject>();
+    public Dictionary<Vector2Int, CollidableObject> collidableCoordinates;
 
     private int maxActions = 0;
 
@@ -141,13 +141,14 @@ public class Board : MonoBehaviour
     {
         StartTurnEvent.AddListener(this.OnStartTurn);
 
+        collidableCoordinates = new Dictionary<Vector2Int, CollidableObject>();
         boardObjects = new List<BoardObject>(GetComponentsInChildren<BoardObject>());
 
         //Bug counting initialization
         numBugs = CountBoardObjectsOfType<Arthropod>();
 
         //Initialize collidables list
-        foreach(CollidableObject collidable in GetBoardObjectsOfType<CollidableObject>()) {
+        foreach(CollidableObject collidable in GetBoardObjectsOfType<CollidableObject>()) {            
             collidableCoordinates.Add(collidable.coordinate, collidable);
         }
 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
@@ -23,6 +23,7 @@ abstract public class Arthropod : BoardObject
         rulesEnabled = false;
         transform.SetParent(player.transform, true);
         GetComponentInChildren<SpriteRenderer>().enabled = false;
+        Debug.Log(this.gameObject.activeSelf);
         player.GetComponent<Player>().setArthropod(this.GetComponent<Arthropod>());
         board.BugCountDecrement();
     }
@@ -43,11 +44,10 @@ abstract public class Arthropod : BoardObject
         board.SetWinCondition(winConIndex, true);
         board.BugCountDecrement();
         board.boardObjects.Remove(this.gameObject.GetComponent<BoardObject>());
+        RemoveListeners();
         this.gameObject.SetActive(false);
         Debug.Log("Swallowed");
     }
-
-
 
     protected void AddActionRule(IActionRule rule)
     {

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
@@ -23,7 +23,6 @@ abstract public class Arthropod : BoardObject
         rulesEnabled = false;
         transform.SetParent(player.transform, true);
         GetComponentInChildren<SpriteRenderer>().enabled = false;
-        Debug.Log(this.gameObject.activeSelf);
         player.GetComponent<Player>().setArthropod(this.GetComponent<Arthropod>());
         board.BugCountDecrement();
     }
@@ -59,6 +58,7 @@ abstract public class Arthropod : BoardObject
     {
         base.OnStartTurn();
         this.coordinate = new Vector2Int((int)transform.position.x, (int)transform.position.y);
+
         //Debug.Log(this.coordinate);
     }
 }

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
@@ -7,9 +7,15 @@ abstract public class Arthropod : BoardObject
     public bool isCaught { get; private set; } = false;
     public bool rulesEnabled = true;
 
-
     public List<IActionRule> rules { get; protected set; } = new List<IActionRule>();
 
+    
+    private int winConIndex;
+    protected override void Start()
+    {
+        base.Start();   
+        winConIndex = board.AllocateWinCondition();
+    }
 
     public virtual void Catch(GameObject player)
     {
@@ -18,6 +24,7 @@ abstract public class Arthropod : BoardObject
         transform.SetParent(player.transform, true);
         GetComponentInChildren<SpriteRenderer>().enabled = false;
         player.GetComponent<Player>().setArthropod(this.GetComponent<Arthropod>());
+        board.BugCountDecrement();
     }
 
     public virtual void Release(GameObject player)
@@ -27,6 +34,17 @@ abstract public class Arthropod : BoardObject
         transform.SetParent(board.transform, true);
         GetComponentInChildren<SpriteRenderer>().enabled = true;
         player.GetComponent<Player>().setArthropod(null);
+        board.BugCountIncrement();
+    }
+
+    public virtual void Swallow(GameObject player)
+    {
+        player.GetComponent<Player>().setArthropod(null);
+        board.SetWinCondition(winConIndex, true);
+        board.BugCountDecrement();
+        board.boardObjects.Remove(this.gameObject.GetComponent<BoardObject>());
+        this.gameObject.SetActive(false);
+        Debug.Log("Swallowed");
     }
 
 
@@ -41,6 +59,6 @@ abstract public class Arthropod : BoardObject
     {
         base.OnStartTurn();
         this.coordinate = new Vector2Int((int)transform.position.x, (int)transform.position.y);
-        Debug.Log(this.coordinate);
+        //Debug.Log(this.coordinate);
     }
 }

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/MovingBug.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/MovingBug.cs
@@ -13,7 +13,9 @@ public class MovingBug : Arthropod
     }
     protected override void OnStartTurn()
     {
+        //Felix: Note that movement continues even after player catches the bug, few different ways to disable this.
         base.OnStartTurn();
+        
         Player player = Board.instance.GetBoardObjectOfType<Player>();
         Vector2Int expectedMove = Vector2Int.zero;
 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/TestBugHold.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/TestBugHold.cs
@@ -19,7 +19,7 @@ public class TestBugHold : Arthropod
                 board,
                 enableConditions: new List<EFMActionRule.EnableCondition> {
                     (BoardObject creator, Board board)
-                        => creator is Arthropod arthropod && arthropod.rulesEnabled
+                        => creator is Arthropod arthropod && arthropod.rulesEnabled && arthropod.gameObject.activeSelf
                 },
                 filter: (BoardAction action) =>
                     action.boardObject is Player

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/TestBugHold.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/TestBugHold.cs
@@ -30,5 +30,11 @@ public class TestBugHold : Arthropod
         );
     }
 
+    protected override void Update()
+    {
+        base.Update();
+        Debug.Log("Active Updating");
+    }
+
 
 }

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
@@ -72,11 +72,16 @@ abstract public class BoardObject : MonoBehaviour
         }
     }
 
-    protected virtual void Start()
+    private void Awake()
     {
         // TODO: Sanitize position to be on the grid?
         // TODO: If there is an offset from the grid, implement for coordinate
         coordinate = new Vector2Int((int)transform.position.x, (int)transform.position.y);
+    }
+    protected virtual void Start()
+    {
+        
+        
 
         board = Board.instance;
 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
@@ -104,6 +104,17 @@ abstract public class BoardObject : MonoBehaviour
         board.PostExecuteEvent.RemoveAllListeners();
     }
 
+    //removes listeners for the functions of this boardobject
+    public void RemoveListeners()
+    {
+        board.StartTurnEvent.RemoveListener(OnStartTurn);
+        board.EndTurnEvent.RemoveListener(OnEndTurn);
+        board.PostEndTurnEvent.RemoveListener(OnPostEndTurn);
+        board.PreExecuteEvent.RemoveListener(OnPostExecute);
+        board.ExecuteEvent.RemoveListener(OnExecute);
+        board.PostExecuteEvent.RemoveListener(OnPostExecute);
+    }
+
     protected virtual void Update()
     {
         if(board.lastBoardEvent == Board.EventState.Execute)

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
@@ -35,7 +35,7 @@ public class Player : BoardObject
 
         if (board.lastBoardEvent == Board.EventState.StartTurn)
         {
-            Debug.Log("Running");
+            //Debug.Log("Running");
 
             //release captured arthropod!
             float release = Input.GetAxisRaw("Release");

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
@@ -35,7 +35,6 @@ public class Player : BoardObject
 
         if (board.lastBoardEvent == Board.EventState.StartTurn)
         {
-            Debug.Log("Running");
 
             //release captured arthropod!
             float release = Input.GetAxisRaw("Release");

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
@@ -50,9 +50,6 @@ public class Player : BoardObject
                 heldArthropod.Swallow(this.gameObject);
             }
 
-            
-
-
             // only move if during a turn
 
             Vector2 input = new Vector2(

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
@@ -35,6 +35,7 @@ public class Player : BoardObject
 
         if (board.lastBoardEvent == Board.EventState.StartTurn)
         {
+            Debug.Log("Running");
 
             //release captured arthropod!
             float release = Input.GetAxisRaw("Release");

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Player.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Player : BoardObject
 {
@@ -24,18 +25,36 @@ public class Player : BoardObject
     protected override void Update()
     {
         base.Update();
+
+        //Check for restart key (TEMP)
+        float restart = Input.GetAxisRaw("Restart");
+        if (!Mathf.Approximately(restart, 0f))
+        {
+            SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+        }
+
         if (board.lastBoardEvent == Board.EventState.StartTurn)
         {
+            Debug.Log("Running");
+
             //release captured arthropod!
             float release = Input.GetAxisRaw("Release");
             if (!Mathf.Approximately(release, 0f) && heldArthropod != null)
             {
-                Debug.Log("R");
                 heldArthropod.Release(this.gameObject);
             }
 
-            // only move if during a turn
+            float swallow = Input.GetAxisRaw("Swallow");
+            if (!Mathf.Approximately(swallow, 0f) && heldArthropod != null)
+            {
+                heldArthropod.Swallow(this.gameObject);
+            }
+
             
+
+
+            // only move if during a turn
+
             Vector2 input = new Vector2(
                 Input.GetAxisRaw("Horizontal"),
                 Input.GetAxisRaw("Vertical")
@@ -63,7 +82,7 @@ public class Player : BoardObject
     protected override void OnStartTurn()
     {
         base.OnStartTurn();
-
+        //Debug.Log("New Turn");
         /*
         Note: The bug overlap has to be checked for at the beginning of the turn since position has to update before we check if player is overlapping,
         however there is currently no implementation for actions to be executed at the beginning of turn 
@@ -98,7 +117,6 @@ public class Player : BoardObject
         {
             if (!arthropod.isCaught && arthropod.coordinate == this.coordinate && heldArthropod == null)
             {
-                board.BugCountUpdate();
                 arthropod.Catch(this.gameObject);
                 break;
             }

--- a/DebuggerGame/ProjectSettings/EditorBuildSettings.asset
+++ b/DebuggerGame/ProjectSettings/EditorBuildSettings.asset
@@ -17,7 +17,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/world_map.unity
     guid: 07986e0c06caff14180d4dedacddf516
-  - enabled: 1
-    path: Assets/Scenes/save screen.unity
-    guid: 6f520bd9267af06458c44ee1fd78dc00
+  - enabled: 0
+    path: 
+    guid: 00000000000000000000000000000000
   m_configObjects: {}

--- a/DebuggerGame/ProjectSettings/InputManager.asset
+++ b/DebuggerGame/ProjectSettings/InputManager.asset
@@ -501,3 +501,35 @@ InputManager:
     type: 0
     axis: 5
     joyNum: 0
+  - serializedVersion: 3
+    m_Name: Swallow
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: t
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 5
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Restart
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: f
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 5
+    joyNum: 0


### PR DESCRIPTION
Swallow/Restart is done. Restart right now is in player update which probably will not be its final resting place but I wasn't sure where else to put it for now. I'm unsure how UI is working currently so I held off on making restart a button in a menu and instead it is bound to the 'f' key. Swallowing is bound to the 't' key. Right now I have a debug message for the win condition is satisfied (for now this is just catching all of the bugs). Note that swallowing deactivates arthropod gameobjects so rules should include "arthropod.gameObject.activeSelf" to ensure arthropod rules aren't still in place after swallowing.