### PR TITLE
Shift Player Behavior and ActionRule rework

### DIFF
--- a/DebuggerGame/Assets/Scripts/Action Scripts/StateActionRule.cs
+++ b/DebuggerGame/Assets/Scripts/Action Scripts/StateActionRule.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IStateActionRule
+{
+    public BoardObject creator { get; }
+    public Board board { get; }
+
+    public BoardAction Execute(BoardAction action, int? offset);
+}
+
+public abstract class EFStateActionRule : IStateActionRule
+{
+    public delegate bool EnableCondition(BoardObject creator, Board board, int? offset);
+    public delegate bool Filter(BoardAction action, int? offset);
+
+    public BoardObject creator { get; protected set; }
+    public Board board { get; protected set; }
+
+    protected EnableCondition enableCondition;
+    protected Filter filter;
+
+    public EFStateActionRule(
+        BoardObject creator,
+        Board board,
+        EnableCondition enableCondition,
+        Filter filter)
+    {
+        this.creator = creator;
+        this.board = board;
+
+        this.enableCondition = enableCondition;
+        this.filter = filter;
+    }
+
+    public abstract BoardAction Execute(BoardAction action, int? offset);
+}
+
+public class EFMStateActionRule : EFStateActionRule
+{
+    public delegate BoardAction Map(BoardAction action, int? offset);
+
+    private Map map;
+
+    public EFMStateActionRule(
+        BoardObject creator,
+        Board board,
+        EnableCondition enableCondition,
+        Filter filter,
+        Map map) : base(creator, board, enableCondition, filter)
+    {
+        this.map = map;
+    }
+
+    public override BoardAction Execute(BoardAction action, int? offset)
+    {
+        if (!enableCondition?.Invoke(creator, board, offset) ?? false)
+        {
+            return action;
+        }
+
+        // filter?.Invoke ?? true means invoke if filter is nonnull, otherwise true
+        if (filter?.Invoke(action, offset) ?? true)
+        {
+            return map(action, offset);
+        }
+        return action;
+    }
+}
+
+
+public class EFStateActionDeleterRule : EFMStateActionRule
+{
+    public EFStateActionDeleterRule(
+        BoardObject creator,
+        Board board,
+        EnableCondition enableCondition,
+        Filter filter) : base(
+            creator,
+            board,
+            enableCondition,
+            filter,
+            (BoardAction action, int? offset) => new NullAction(action.boardObject)
+        )
+    { }
+}

--- a/DebuggerGame/Assets/Scripts/Action Scripts/StateActionRule.cs.meta
+++ b/DebuggerGame/Assets/Scripts/Action Scripts/StateActionRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 379c8a111a9209d43beb77b13c544e10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/ActionlessBoardObject.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/ActionlessBoardObject.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ActionlessBoardObject : BoardObject
+{
+    protected override void Update()
+    { }
+
+    protected override void OnPreExecute()
+    { }
+
+    protected override void OnPostExecute()
+    { }
+}

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/ActionlessBoardObject.cs.meta
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/ActionlessBoardObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8c8aa19ddcf81c458e54d111d24bac3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/Arthropod.cs
@@ -47,6 +47,7 @@ abstract public class Arthropod : BoardObject
     {
         player.GetComponent<Player>().setArthropod(null);
         board.SetWinCondition(winConIndex, true);
+        board.DeallocateActionsLeft(this);
         board.BugCountDecrement();
         board.boardObjects.Remove(this.gameObject.GetComponent<BoardObject>());
         RemoveListeners();

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/MovePlayerArthropod.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/MovePlayerArthropod.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MovePlayerArthropod : Arthropod
+{
+    [SerializeField]
+    protected List<Vector2Int> movements = new List<Vector2Int>();
+
+    override protected void OnEndTurn()
+    {
+        base.OnEndTurn();
+
+        if (rulesEnabled)
+        {
+            var player = board.GetBoardObjectOfType<Player>();
+            foreach (var direction in movements)
+            {
+                player.actions.Enqueue(new MovementAction(
+                    player, direction
+                ));
+            }
+        }
+    }
+}

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/MovePlayerArthropod.cs.meta
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/Arthropod Scripts/MovePlayerArthropod.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a74b853aab19bc4c84bcfb30533fe1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
@@ -84,7 +84,7 @@ abstract public class BoardObject : MonoBehaviour
             if(actions.Count == 1)
             {
                 executingActionOffset = actionOffset;
-                board.SetActionsLeft(actionsLeftIndex.Value, 1);
+                board.SetActionsLeft(this, 1);
             }
         }
     }
@@ -132,7 +132,7 @@ abstract public class BoardObject : MonoBehaviour
         board.StartTurnEvent.RemoveListener(OnStartTurn);
         board.EndTurnEvent.RemoveListener(OnEndTurn);
         board.PostEndTurnEvent.RemoveListener(OnPostEndTurn);
-        board.PreExecuteEvent.RemoveListener(OnPostExecute);
+        board.PreExecuteEvent.RemoveListener(OnPreExecute);
         board.ExecuteEvent.RemoveListener(OnExecute);
         board.PostExecuteEvent.RemoveListener(OnPostExecute);
         board.EndLevelEvent.RemoveListener(OnEndLevel);
@@ -152,6 +152,7 @@ abstract public class BoardObject : MonoBehaviour
                 {
                     // state dependent filter disallowed action
                     executingAction = null;
+                    board.SetActionsLeft(this, actions.Count);
                 }
                 else
                 {
@@ -164,7 +165,7 @@ abstract public class BoardObject : MonoBehaviour
                     {
                         executingAction.ExecuteFinish();
                         executingAction = null;
-                        board.SetActionsLeft(actionsLeftIndex.Value, actions.Count);
+                        board.SetActionsLeft(this, actions.Count);
                     }
                 }
                 
@@ -182,7 +183,7 @@ abstract public class BoardObject : MonoBehaviour
                 // If it has been at least 1.0 actions since when the action started, the action finished
                 executingAction?.ExecuteFinish();
                 executingAction = null;
-                board.SetActionsLeft(actionsLeftIndex.Value, actions.Count);
+                board.SetActionsLeft(this, actions.Count);
             }
         }
     }
@@ -226,8 +227,8 @@ abstract public class BoardObject : MonoBehaviour
             // If the action uses a turn, then add 1 to max actions
             actionsLeft += action.usesTime ? 1 : 0;
         }
-        actionsLeftIndex = board.AllocateActionCount();
-        board.SetActionsLeft(actionsLeftIndex.Value, actionsLeft);
+        actionsLeftIndex = board.AllocateActionsLeft(this);
+        board.SetActionsLeft(this, actionsLeft);
         // See BoardObject.Update for continuation of the logic
     }
 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/BoardObject.cs
@@ -89,6 +89,34 @@ abstract public class BoardObject : MonoBehaviour
         }
     }
 
+    public BoardAction PeekNextBoardAction()
+    {
+        if(executingAction != null)
+        {
+            return executingAction;
+        }
+        else if(actions.Count > 0)
+        {
+            return actions.Peek();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public Vector2Int PeekNextWeakCoordinate()
+    {
+        if(!(PeekNextBoardAction() is MovementAction movementAction))
+        {
+            return coordinate;
+        }
+        else
+        {
+            return coordinate + movementAction.direction;
+        }
+    }
+
 
     private void Awake()
     {

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/CollidableObject.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/CollidableObject.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class CollidableObject : BoardObject
+public class CollidableObject : ActionlessBoardObject
 {
     public bool bugsCanPass = false;
 

--- a/DebuggerGame/Assets/Scripts/BoardObject Scripts/PushableObject.cs
+++ b/DebuggerGame/Assets/Scripts/BoardObject Scripts/PushableObject.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class PushableObject : BoardObject
 {
-    public bool Push(Vector2Int direction) {
+    public bool Push(Vector2Int direction, int? actionOffset) {
         Vector2Int newCoordinate = this.coordinate + direction;
         BoardObject objectAtNewCoordinate = Board.instance.GetBoardObjectAtCoordinate(this.coordinate + direction);
 
@@ -15,14 +15,14 @@ public class PushableObject : BoardObject
         }
         else if(objectAtNewCoordinate is PushableObject) {
             PushableObject pushableAtNewCoordinate = (PushableObject)objectAtNewCoordinate;
-            if(pushableAtNewCoordinate.Push(direction)) {
-                actions.Enqueue(new MovementAction(this, direction));
+            if(pushableAtNewCoordinate.Push(direction, actionOffset)) {
+                AddActionMidExecution(new MovementAction(this, direction), actionOffset);
                 return true;
             }
             return false;
         }
         else if(objectAtNewCoordinate == null) {
-            actions.Enqueue(new MovementAction(this, direction));
+            AddActionMidExecution(new MovementAction(this, direction), actionOffset);
             return true;
         }
         return false;

--- a/DebuggerGame/Assets/Scripts/CameraManager.cs
+++ b/DebuggerGame/Assets/Scripts/CameraManager.cs
@@ -7,6 +7,9 @@ public class CameraManager : MonoBehaviour
     [SerializeField]
     private float sizePadding = 1f;
 
+    [SerializeField]
+    private Vector2Int offset = new Vector2Int(0, 0);
+
     private Board board;
 
     private float? lastAspect = null;
@@ -31,19 +34,24 @@ public class CameraManager : MonoBehaviour
     {
         lastAspect = safeScreenAspect;
 
+        // Center camera
         Camera.main.gameObject.transform.position = new Vector3(
-            board.width / 2f - 0.5f, board.height / 2f - 0.5f,
+            (board.width)/ 2f + offset.x, (board.height) / 2f + offset.y,
             Camera.main.gameObject.transform.position.z
         );
         
-        float boardAspect = (float)board.width / board.height;
+        float boardAspect = (float)(board.width + 2*sizePadding)/ (board.height + 2 * sizePadding);
         if(boardAspect > lastAspect)
         {
-            Camera.main.orthographicSize = board.width / 2f + 2 * sizePadding;
+            // width can vary freely
+            // half-height will be determined by the half-width
+            Camera.main.orthographicSize = (board.width / 2f + sizePadding)/lastAspect.Value;
         }
         else
         {
-            Camera.main.orthographicSize = board.height / 2f + 2 * sizePadding;
+            // height can vary freely without making board go off screen
+            // half-height based off of board height
+            Camera.main.orthographicSize = board.height / 2f + sizePadding;
         }
     }
 }

--- a/DebuggerGame/Assets/Scripts/CameraManager.cs
+++ b/DebuggerGame/Assets/Scripts/CameraManager.cs
@@ -36,7 +36,7 @@ public class CameraManager : MonoBehaviour
 
         // Center camera
         Camera.main.gameObject.transform.position = new Vector3(
-            (board.width)/ 2f + offset.x, (board.height) / 2f + offset.y,
+            (board.width-1)/ 2f + offset.x, (board.height-1) / 2f + offset.y,
             Camera.main.gameObject.transform.position.z
         );
         


### PR DESCRIPTION
Reworked actionrules (keeping old behavior as backwards compatible) to include StateActionRule, which, so far, is only used by the board to add actionrules that depend on the state (eg. player position [for boundaries] or current action offset [to add a new action])
Made it so actions can be added mid execution, reworking how the counter works